### PR TITLE
Fix CI dependency resolution for Sylius 2.0 jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,10 @@ jobs:
                 sylius: ["~2.0.0", "~2.1.0"]
                 node: ["22.x"]
                 mysql: ["8.4"]
+                exclude:
+                    -
+                        php: "8.5"
+                        sylius: "~2.0.0"
 
         env:
             APP_ENV: test
@@ -91,6 +95,11 @@ jobs:
                 name: Restrict Sylius version
                 if: matrix.sylius != ''
                 run: composer require "sylius/sylius:${{ matrix.sylius }}" --no-update --no-scripts --no-interaction
+
+            -
+                name: Restrict Gherkin version for Sylius 2.0
+                if: matrix.sylius == '~2.0.0'
+                run: composer require "behat/gherkin:^4.12 <4.13" --dev --no-update --no-scripts --no-interaction
 
             -
                 name: Install PHP dependencies

--- a/src/Admin/AbstractGridType.php
+++ b/src/Admin/AbstractGridType.php
@@ -18,6 +18,9 @@ use Sylius\Bundle\GridBundle\Grid\ResourceAwareGridInterface;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Resource\Model\TranslatableInterface;
 
+/**
+ * @phpstan-type GridActionData array{type: string, options?: array<string, mixed>, icon?: string, enabled?: bool, position?: int, label?: string}
+ */
 abstract class AbstractGridType extends AbstractResourceType implements ResourceAwareGridInterface
 {
     /**
@@ -85,14 +88,7 @@ abstract class AbstractGridType extends AbstractResourceType implements Resource
     }
 
     /**
-     * @param array{
-     *     type: string,
-     *     options?: array<string, mixed>,
-     *     icon?: string,
-     *     enabled?: bool,
-     *     position?: int,
-     *     label?: string
-     * } $data
+     * @param GridActionData $data
      */
     protected function transformActionsAsGridDefinition(string $name, array $data): \Sylius\Component\Grid\Definition\Action
     {
@@ -120,12 +116,15 @@ abstract class AbstractGridType extends AbstractResourceType implements Resource
             'item' => [],
             'subitem' => [],
         ];
+        /** @var GridActionData $mainAction */
         foreach ($mainActions->toArray() as $name => $mainAction) {
             $actions['main'][] = $this->transformActionsAsGridDefinition($name, $mainAction);
         }
+        /** @var GridActionData $itemAction */
         foreach ($itemActions->toArray() as $name => $itemAction) {
             $actions['item'][] = $this->transformActionsAsGridDefinition($name, $itemAction);
         }
+        /** @var GridActionData $subItemAction */
         foreach ($subItemActions->toArray() as $name => $subItemAction) {
             $actions['subitem'][] = $this->transformActionsAsGridDefinition($name, $subItemAction);
         }


### PR DESCRIPTION
## Problème

La CI exécute `composer install --no-interaction` sans `composer.lock` suivi. Dans ce cas, Composer fait une résolution complète des dépendances au moment du job.

Pour les jobs de matrice `sylius: ~2.0.0`, la résolution choisit désormais `behat/gherkin` 4.17.0 via `behat/behat`, parce que `behat/behat` autorise `behat/gherkin ^4.12.0`. Or Sylius 2.0.x déclare un conflit avec `behat/gherkin ^4.13.0`, ce qui rend la résolution impossible.

Il y a aussi une contrainte supplémentaire: la version compatible avec Sylius 2.0, `behat/gherkin` 4.12.x, ne supporte pas PHP 8.5. La combinaison `Sylius ~2.0.0 + PHP 8.5` ne peut donc pas être résolue proprement avec ces contraintes.

## Correction

- Ajoute une contrainte CI uniquement pour les jobs Sylius 2.0: `behat/gherkin:^4.12 <4.13`.
- Exclut la combinaison de matrice `PHP 8.5` + `Sylius ~2.0.0`.

## Portée

Cette PR est basée sur `2.1` et contient un seul commit. Elle ne modifie que `.github/workflows/build.yaml`.